### PR TITLE
Check null STRING flow vars

### DIFF
--- a/org.knime.base.expressions.tests/src/test/java/org/knime/base/expressions/node/row/filter/ExpressionRowFilterNodeScriptingDiagnosticsTest.java
+++ b/org.knime.base.expressions.tests/src/test/java/org/knime/base/expressions/node/row/filter/ExpressionRowFilterNodeScriptingDiagnosticsTest.java
@@ -186,6 +186,21 @@ final class ExpressionRowFilterNodeScriptingDiagnosticsTest {
     }
 
     @Test
+    void testNullFlowVariable() {
+        var vars = new java.util.HashMap<>(FLOW_VARIABLES);
+        vars.put("null_var", new FlowVariable("null_var", StringType.INSTANCE, null));
+        var service = createService(getWorkflowControl(TABLE_SPECS, vars));
+        var diagnostics = service.getRowFilterDiagnostics("$$null_var = 'x'");
+
+        assertFalse(diagnostics.isEmpty(), "Expected error for null flow variable.");
+        assertEquals(1, diagnostics.size(), "Expected exactly one diagnostic.");
+        assertEquals(DiagnosticSeverity.ERROR, diagnostics.get(0).severity(),
+            "Expected error severity for null flow variable.");
+        assertEquals("The STRING flow variable 'null_var' has the value null.", diagnostics.get(0).message(),
+            "Expected null flow variable error message.");
+    }
+
+    @Test
     void testExpressionEvaluatesToInt() {
         var service = createService(getWorkflowControl(TABLE_SPECS, FLOW_VARIABLES));
         var diagnostics = service.getRowFilterDiagnostics("$int + 1");

--- a/org.knime.base.expressions.tests/src/test/java/org/knime/base/expressions/node/row/mapper/ExpressionRowMapperNodeScriptingDiagnosticsTest.java
+++ b/org.knime.base.expressions.tests/src/test/java/org/knime/base/expressions/node/row/mapper/ExpressionRowMapperNodeScriptingDiagnosticsTest.java
@@ -216,6 +216,21 @@ final class ExpressionRowMapperNodeScriptingDiagnosticsTest {
         );
     }
 
+
+    @Test
+    void testNullFlowVariable() {
+        var vars = new java.util.HashMap<>(FLOW_VARIABLES);
+        vars.put("null_var", new FlowVariable("null_var", StringType.INSTANCE, null));
+        var service = createService(getWorkflowControl(TABLE_SPECS, vars));
+        var result = service.getRowMapperDiagnostics(new String[]{"$$null_var"}, new String[]{"out"});
+
+        assertEquals(1, result.size(), "Expected diagnostics for one expression.");
+        assertFalse(result.get(0).diagnostics().isEmpty(), "Expected error for null flow variable.");
+        assertEquals(DiagnosticSeverity.ERROR, result.get(0).diagnostics().get(0).severity(),
+            "Expected error severity for null flow variable.");
+        assertEquals("The STRING flow variable 'null_var' has the value null.",
+            result.get(0).diagnostics().get(0).message(), "Expected null flow variable error message.");
+    }
     @Test
     void testExpressionEvaluatesToMissing() {
         var service = createService(getWorkflowControl(TABLE_SPECS, FLOW_VARIABLES));

--- a/org.knime.base.expressions.tests/src/test/java/org/knime/base/expressions/node/variable/ExpressionFlowVariableNodeScriptingDiagnosticsTest.java
+++ b/org.knime.base.expressions.tests/src/test/java/org/knime/base/expressions/node/variable/ExpressionFlowVariableNodeScriptingDiagnosticsTest.java
@@ -173,13 +173,27 @@ final class ExpressionFlowVariableNodeScriptingDiagnosticsTest {
         assertFalse(result.get(0).diagnostics().isEmpty(), "Expected error for unsupported flow variable type.");
         assertEquals(DiagnosticSeverity.ERROR, result.get(0).diagnostics().get(0).severity(),
             "Expected error severity for unsupported flow variable type.");
-        assertEquals( //
-            "Flow variables of the type 'INTARRAY' are not supported in expressions.", //
-            result.get(0).diagnostics().get(0).message(), //
-            "Expected unsupported flow variable type error message." //
-        );
+        assertEquals(
+            "Flow variables of the type 'INTARRAY' are not supported",
+            result.get(0).diagnostics().get(0).message(),
+            "Expected unsupported flow variable type error message.");
     }
 
+
+    @Test
+    void testNullFlowVariable() {
+        var vars = new java.util.HashMap<>(FLOW_VARIABLES);
+        vars.put("null_var", new FlowVariable("null_var", StringType.INSTANCE, null));
+        var service = createService(getWorkflowControl(vars));
+        var result = service.getFlowVariableDiagnostics(new String[]{"$$null_var"}, new String[]{"out"});
+
+        assertEquals(1, result.size(), "Expected diagnostics for one expression.");
+        assertFalse(result.get(0).diagnostics().isEmpty(), "Expected error for null flow variable.");
+        assertEquals(DiagnosticSeverity.ERROR, result.get(0).diagnostics().get(0).severity(),
+            "Expected error severity for null flow variable.");
+        assertEquals("The STRING flow variable 'null_var' has the value null.",
+            result.get(0).diagnostics().get(0).message(), "Expected null flow variable error message.");
+    }
     @Test
     void testUnsupportedColumnAccess() {
         var service = createService(getWorkflowControl(FLOW_VARIABLES));

--- a/org.knime.base.expressions/src/main/java/org/knime/base/expressions/ExpressionRunnerUtils.java
+++ b/org.knime.base.expressions/src/main/java/org/knime/base/expressions/ExpressionRunnerUtils.java
@@ -582,11 +582,22 @@ public final class ExpressionRunnerUtils {
      */
     public static Function<String, ReturnResult<ValueType>>
         flowVarToTypeForTypeInference(final Map<String, FlowVariable> flowVars) {
-        return name -> ReturnResult
-            .fromNullable(flowVars.get(name), "No flow variable with the name '" + name + "' is available.") //
-            .map(FlowVariable::getVariableType) //
-            .flatMap(type -> ReturnResult.fromNullable(mapVariableToValueType(type),
-                "Flow variables of the type '" + type + "' are not supported"));
+        return name -> {
+            var flowVar = flowVars.get(name);
+            if (flowVar == null) {
+                return ReturnResult.failure("No flow variable with the name '" + name + "' is available.");
+            }
+
+            if (flowVar.getVariableType() == VariableType.StringType.INSTANCE
+                && flowVar.getValue(VariableType.StringType.INSTANCE) == null) {
+                return ReturnResult.failure(
+                    "The STRING flow variable '" + name + "' has the value null.");
+            }
+
+            var valueType = mapVariableToValueType(flowVar.getVariableType());
+            return ReturnResult.fromNullable(valueType,
+                "Flow variables of the type '" + flowVar.getVariableType() + "' are not supported");
+        };
     }
 
     /**

--- a/org.knime.base.expressions/src/main/java/org/knime/base/expressions/node/variable/ExpressionFlowVariableNodeModel.java
+++ b/org.knime.base.expressions/src/main/java/org/knime/base/expressions/node/variable/ExpressionFlowVariableNodeModel.java
@@ -364,11 +364,8 @@ final class ExpressionFlowVariableNodeModel extends NodeModel {
 
     /** Helper to get the ValueType of a flow variable from the given map (use for type inference) */
     static ReturnResult<ValueType> toValueType(final Map<String, FlowVariable> flowVariables, final String name) {
-        return ReturnResult
-            .fromNullable(flowVariables.get(name), "No flow variable with the name '" + name + "' is available.") //
-            .map(FlowVariable::getVariableType) //
-            .flatMap(type -> ReturnResult.fromNullable(ExpressionRunnerUtils.mapVariableToValueType(type),
-                "Flow variables of the type '" + type + "' are not supported in expressions."));
+        return ExpressionRunnerUtils.flowVarToTypeForTypeInference(flowVariables)
+            .apply(name);
     }
 
     private static Optional<Computer> toComputer(final Map<String, FlowVariable> flowVariables,

--- a/org.knime.base.expressions/src/main/java/org/knime/base/expressions/node/variable/ExpressionFlowVariableNodeScriptingService.java
+++ b/org.knime.base.expressions/src/main/java/org/knime/base/expressions/node/variable/ExpressionFlowVariableNodeScriptingService.java
@@ -314,11 +314,9 @@ final class ExpressionFlowVariableNodeScriptingService extends ScriptingService 
                 return ReturnResult.failure("No flow variable with the name '" + name + "' is available.");
             }
 
-            return flowVariableResult //
-                .flatMap(flowVariable -> ReturnResult.fromNullable(
-                    ExpressionRunnerUtils.mapVariableToValueType(flowVariable.getVariableType()),
-                    "Flow variables of the type '" + flowVariable.getVariableType()
-                        + "' are not supported in expressions."));
+            return flowVariableResult.flatMap(flowVariable ->
+                ExpressionRunnerUtils.flowVarToTypeForTypeInference(Map.of(name, flowVariable))
+                    .apply(name));
         }
 
     }


### PR DESCRIPTION
## Summary
- validate STRING flow variables are not null during configure
- use `ExpressionRunnerUtils.flowVarToTypeForTypeInference` in Flow Variable node
- simplify UI service type lookup to use the same util
- update diagnostic expectation for unsupported flow variable types

## Testing
- `mvn -q -DskipTests install` *(fails: command not found)*